### PR TITLE
Adding scopes to all endpoints in the authorize

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -117,9 +117,9 @@ function createPostPushPutOutput(verbs, definitions, pathKeys, path) {
         let authorizer = _.keys(swagger.securityDefinitions)[0];
         if (authHeaderGroupRegExp.test(headerAuthorizerParam.group)) {
             authorizer = headerAuthorizerParam.group;
-        } 
+        }
         pathItemObject[verbs.type].security = [{
-            [authorizer]: []
+            [authorizer]: swagger.securityDefinitions[authorizer].scopes || []
         }]
     }
 
@@ -303,7 +303,7 @@ function createGetDeleteOutput(verbs,definitions, path) {
     if (swagger.securityDefinitions && headerAuthorizerParam) {
         if (authHeaderGroupRegExp.test(headerAuthorizerParam.group)) {
             pathItemObject[verbs.type].security = [{
-                [headerAuthorizerParam.group]: []
+                [headerAuthorizerParam.group]: swagger.securityDefinitions[headerAuthorizerParam.group].scopes || []
             }]
         } 
     }


### PR DESCRIPTION
Resolves the use of scopes on all endpoints that use the same authorizer.